### PR TITLE
Remove commit method.

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -32,7 +32,4 @@ pub trait Repository {
         id: Self::Id,
         command: &<Self::Aggregate as Aggregate>::Command,
     ) -> Result<Self::CommandResponse, Self::Error>;
-
-    /// Commit the changes made by the handled command.
-    fn commit(&mut self) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
RepositoryとAggregateは対応している
Aggregate内でhandle_commandした時点でコミットまで行うべきと考えてcommitを削除